### PR TITLE
update speakers; hide cube on small screens

### DIFF
--- a/components/scotty.tsx
+++ b/components/scotty.tsx
@@ -28,7 +28,7 @@ export default function Scotty() {
   }, []);
 
   return (
-    <div ref={container} className="-mr-48 z-50">
+    <div ref={container} className="-mr-48 z-50 hidden md:block">
       <Canvas>
         <OrbitControls enableZoom={false} enablePan={false} />
         <ambientLight intensity={3} />


### PR DESCRIPTION
# Description

- Updates the speaker page to include photos
- Removes the Scotty cube on small screens (otherwise it blocks the text)